### PR TITLE
Issue 2/create working nix shell andor flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ scribble.css
 
 #TAGS file
 TAGS
+
+# Cache and other dev setup files
+.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1722436989,
+        "narHash": "sha256-hSghp0a/WLYiib0rDQGxNKNJDpBh0Zxl3HS/xC2ETHI=",
+        "owner": "MuKnIO",
+        "repo": "nixpkgs",
+        "rev": "e5fe4bf5664a34a4b4da758183480d09474d0162",
+        "type": "github"
+      },
+      "original": {
+        "owner": "MuKnIO",
+        "ref": "devel",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -78,12 +78,12 @@
           default = self.packages.${system}.skyprotocol;
         };
 
-        # apps = {
-        #   default = {
-        #     type = "app";
-        #     program = self.packages.${system}.skyprotocol;
-        #   };
-        # };
+        apps = {
+          default = {
+            type = "app";
+            program = "${self.packages.${system}.skyprotocol}/bin/sky";
+          };
+        };
 
         devShells.default = mkShell {
           buildInputs = devTools;

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,102 @@
+{
+  inputs = {
+    nixpkgs.url = "github:MuKnIO/nixpkgs/devel";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        # ethereum = true;
+        pkgs = nixpkgs.legacyPackages.${system};
+        # usefull tools to build gerbil packages
+        gerbilTools = pkgs.gerbil-support;
+        # gerbil packages
+        gPkgs = pkgs.gerbilPackages-unstable;
+
+        gerbilInputs = with gPkgs; [
+          gerbil-utils
+          gerbil-crypto
+          gerbil-poo
+          gerbil-persist
+          gerbil-ethereum
+          gerbil-leveldb
+          # gerbil-libp2p
+        ];
+        devTools = with pkgs; [
+          gerbil-unstable
+        ] ++ gerbilInputs
+        ++ self.packages.${system}.skyprotocol.buildInputs;
+      in
+      with pkgs;
+      {
+        overlays.default = (final: prev: {
+          skyprotocol = self.packages.${final.system}.skyprotocol;
+          legacyPackages.${final.system}.gerbilPackages-unstable = prev.legacyPackages.${final.system}.gerbilPackages-unstable // {
+            skyprotocol = self.packages.${final.system}.skyprotocol;
+          };
+        });
+        packages = {
+          skyprotocol = gerbilTools.gerbilPackage {
+            pname = "skyprotocol";
+            version = "0.1";
+            softwareName = "SkyProtocol";
+            gerbil-package = "skyprotocol";
+            version-path = "version";
+
+            pre-src = gerbilTools.path-src (gerbilTools.gerbilFilterSource ./.);
+
+            gerbilInputs = gerbilInputs;
+            postInstall = ''
+              mkdir -p $out/bin $out/gerbil/lib/skyprotocol
+              cp main.ss $out/gerbil/lib/skyprotocol/
+              cat > $out/bin/sky <<EOF
+              #!/bin/sh
+              ORIG_GERBIL_LOADPATH="\$GERBIL_LOADPATH"
+              ORIG_GERBIL_PATH="\$GERBIL_PATH"
+              ORIG_GERBIL_HOME="\$GERBIL_HOME"
+              unset GERBIL_HOME
+              GERBIL_LOADPATH="${gerbilTools.gerbilLoadPath (["$out"] ++ gerbilInputs)}"
+              SKY_SOURCE="\''${SKY_SOURCE:-$out/share/sky}"
+              GERBIL_PATH="\$HOME/.cache/sky/gerbil"
+              export GERBIL_PATH GERBIL_LOADPATH SKY_SOURCE ORIG_GERBIL_PATH ORIG_GERBIL_LOADPATH ORIG_GERBIL_HOME
+              exec ${pkgs.gerbil-unstable}/bin/gxi $out/gerbil/lib/skyprotocol/main.ss "\$@"
+              EOF
+              chmod a+x $out/bin/sky
+            '';
+
+            meta = with lib; {
+              description = "Sky Protocol: Data Availability for safe modular Decentralized Applications (DApps)";
+              homepage = "https://skyprotocol.org";
+              license = licenses.asl20;
+              platforms = platforms.unix;
+              maintainers = with maintainers; [ fare ];
+            };
+
+          };
+
+          default = self.packages.${system}.skyprotocol;
+        };
+
+        # apps = {
+        #   default = {
+        #     type = "app";
+        #     program = self.packages.${system}.skyprotocol;
+        #   };
+        # };
+
+        devShells.default = mkShell {
+          buildInputs = devTools;
+          LD_LIBRARY_PATH = lib.makeLibraryPath devTools;
+          shellHook = ''
+            ${self.packages.${system}.skyprotocol.postConfigure}
+            PATH="${self.packages.${system}.skyprotocol.out}/bin:$PATH"
+            GERBIL_APPLICATION_HOME="$PWD"
+            GERBIL_APPLICATION_SOURCE="$PWD"
+            GLOW_HOME="$PWD"
+            GLOW_SRC="$PWD"
+          '';
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
       let
         # ethereum = true;
         pkgs = nixpkgs.legacyPackages.${system};
-        # usefull tools to build gerbil packages
+        # useful tools to build gerbil packages
         gerbilTools = pkgs.gerbil-support;
         # gerbil packages
         gPkgs = pkgs.gerbilPackages-unstable;
@@ -47,6 +47,7 @@
             pre-src = gerbilTools.path-src (gerbilTools.gerbilFilterSource ./.);
 
             gerbilInputs = gerbilInputs;
+
             postInstall = ''
               mkdir -p $out/bin $out/gerbil/lib/skyprotocol
               cp main.ss $out/gerbil/lib/skyprotocol/
@@ -93,8 +94,6 @@
             PATH="${self.packages.${system}.skyprotocol.out}/bin:$PATH"
             GERBIL_APPLICATION_HOME="$PWD"
             GERBIL_APPLICATION_SOURCE="$PWD"
-            GLOW_HOME="$PWD"
-            GLOW_SRC="$PWD"
           '';
         };
       }

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -4,62 +4,87 @@ let
 
   config = {
     packageOverrides = superPkgs:
-      let superGS = superPkgs.gerbil-support;
-          superPPU = superGS.prePackages-unstable;
-          inherit (superGS) path-src overrideSrcIfShaDiff gerbilFilterSource gerbilLoadPath
-                  gerbilVersionFromGit;
-          source = gerbilFilterSource ./.; in
+      let
+        superGS = superPkgs.gerbil-support;
+        superPPU = superGS.prePackages-unstable;
+        inherit (superGS) path-src overrideSrcIfShaDiff gerbilFilterSource gerbilLoadPath
+          gerbilVersionFromGit;
+        source = gerbilFilterSource ./.;
+      in
       rec {
         gerbil-support = superGS // {
           inherit pkgs;
           # Skip extra files so we can play with CI configuration yet have the CI reuse cached builds.
           gerbilSkippableFiles = superGS.gerbilSkippableFiles ++
-            [".gitlab.yml" ".github" "pkgs.nix" "shell.nix" "default.nix" "docs" "future" "dep"
-             "Dockerfile" "Dockerfile.nixos" "sky-install" "ci.ss" ".build"];
+            [
+              ".gitlab.yml"
+              ".github"
+              "pkgs.nix"
+              "shell.nix"
+              "default.nix"
+              "docs"
+              "future"
+              "dep"
+              "Dockerfile"
+              "Dockerfile.nixos"
+              "sky-install"
+              "ci.ss"
+              ".build"
+            ];
 
           prePackages-unstable =
-            let skyprotocol = rec {
-              pname = "skyprotocol";
-              softwareName = "SkyProtocol";
-              gerbil-package = "skyprotocol";
-              version-path = "version";
-              gerbilInputs = with pkgs.gerbil-support.gerbilPackages-unstable;
-                [ gerbil-utils gerbil-crypto gerbil-poo gerbil-persist gerbil-ethereum
-                  gerbil-leveldb # gerbil-libp2p
+            let
+              skyprotocol = rec {
+                pname = "skyprotocol";
+                softwareName = "SkyProtocol";
+                gerbil-package = "skyprotocol";
+                version-path = "version";
+                gerbilInputs = with pkgs.gerbil-support.gerbilPackages-unstable;
+                  [
+                    gerbil-utils
+                    gerbil-crypto
+                    gerbil-poo
+                    gerbil-persist
+                    gerbil-ethereum
+                    gerbil-leveldb # gerbil-libp2p
                   ];
-              pre-src = path-src source;
-              postInstall = ''
-                mkdir -p $out/bin $out/gerbil/lib/skyprotocol
-                cp main.ss $out/gerbil/lib/skyprotocol/
-                cat > $out/bin/sky <<EOF
-                #!/bin/sh
-                ORIG_GERBIL_LOADPATH="\$GERBIL_LOADPATH"
-                ORIG_GERBIL_PATH="\$GERBIL_PATH"
-                ORIG_GERBIL_HOME="\$GERBIL_HOME"
-                unset GERBIL_HOME
-                GERBIL_LOADPATH="${gerbil-support.gerbilLoadPath (["$out"] ++ gerbilInputs)}"
-                SKY_SOURCE="\''${SKY_SOURCE:-$out/share/glow}"
-                GERBIL_PATH="\$HOME/.cache/sky/gerbil"
-                export GERBIL_PATH GERBIL_LOADPATH SKY_SOURCE ORIG_GERBIL_PATH ORIG_GERBIL_LOADPATH ORIG_GERBIL_HOME
-                exec ${pkgs.gerbil-unstable}/bin/gxi $out/gerbil/lib/skyprotocol/main.ss "\$@"
-                EOF
-                chmod a+x $out/bin/sky
+                pre-src = path-src source;
+                postInstall = ''
+                  mkdir -p $out/bin $out/gerbil/lib/skyprotocol
+                  cp main.ss $out/gerbil/lib/skyprotocol/
+                  cat > $out/bin/sky <<EOF
+                  #!/bin/sh
+                  ORIG_GERBIL_LOADPATH="\$GERBIL_LOADPATH"
+                  ORIG_GERBIL_PATH="\$GERBIL_PATH"
+                  ORIG_GERBIL_HOME="\$GERBIL_HOME"
+                  unset GERBIL_HOME
+                  GERBIL_LOADPATH="${gerbil-support.gerbilLoadPath (["$out"] ++ gerbilInputs)}"
+                  SKY_SOURCE="\''${SKY_SOURCE:-$out/share/glow}"
+                  GERBIL_PATH="\$HOME/.cache/sky/gerbil"
+                  export GERBIL_PATH GERBIL_LOADPATH SKY_SOURCE ORIG_GERBIL_PATH ORIG_GERBIL_LOADPATH ORIG_GERBIL_HOME
+                  exec ${pkgs.gerbil-unstable}/bin/gxi $out/gerbil/lib/skyprotocol/main.ss "\$@"
+                  EOF
+                  chmod a+x $out/bin/sky
                 '';
 
-              meta = with lib; {
-                description = "Sky Protocol: Data Availability for safe modular Decentralized Applications (DApps)";
-                homepage    = "https://skyprotocol.org";
-                license     = licenses.asl20;
-                platforms   = platforms.unix;
-                maintainers = with maintainers; [ fare ];
-              };
-            } // gerbilVersionFromGit source "version"; in
-            superPPU // { inherit skyprotocol;};};
+                meta = with lib; {
+                  description = "Sky Protocol: Data Availability for safe modular Decentralized Applications (DApps)";
+                  homepage = "https://skyprotocol.org";
+                  license = licenses.asl20;
+                  platforms = platforms.unix;
+                  maintainers = with maintainers; [ fare ];
+                };
+              } // gerbilVersionFromGit source "version";
+            in
+            superPPU // { inherit skyprotocol; };
+        };
 
         skyprotocol = gerbil-support.gerbilPackages-unstable.skyprotocol;
 
         testGerbilLoadPath =
           "${gerbilLoadPath ([skyprotocol] ++ skyprotocol.passthru.pre-pkg.gerbilInputs)}:${source}";
 
-      };}; in
-  pkgs
+      };
+  };
+in
+pkgs

--- a/shell.nix
+++ b/shell.nix
@@ -15,7 +15,7 @@ pkgs.mkShell {
   buildInputs = with pkgs; (
     skyprotocol.buildInputs ++
     lib.optional ethereum go-ethereum ++
-    [ netcat go-libp2p-daemon ] # used by integration tests
+    [ netcat ] # used by integration tests
     # TODO: Save at compile time
     # the path to the p2pd (go-libp2p-daemon) binary.
     # The path is useful because it is a hash -

--- a/shell.nix
+++ b/shell.nix
@@ -8,31 +8,31 @@ let
   inherit (gerbilPackages-unstable) gerbil-ethereum gerbil-poo;
   inherit (gerbil-support) gerbilLoadPath;
 in
-  pkgs.mkShell {
-    inputsFrom = [
-      skyprotocol
-    ];
-    buildInputs = with pkgs; (
-      skyprotocol.buildInputs ++
-      lib.optional ethereum go-ethereum ++
-      [ netcat go-libp2p-daemon ] # used by integration tests
-                                  # TODO: Save at compile time
-                                  # the path to the p2pd (go-libp2p-daemon) binary.
-                                  # The path is useful because it is a hash -
-                                  # so nix knows we depend on this exact version.
-      );
-    shellHook = ''
-      echo ${gerbil-poo.src}; echo ${pkgs.gerbilPackages-unstable.gerbil-poo.src} ; echo
-      echo ${skyprotocol.src}; echo ${pkgs.gerbilPackages-unstable.skyprotocol.src} ; echo ${pkgs.gerbilPackages-unstable.skyprotocol.src} ; echo ${pkgs.gerbil-support.gerbilPackages-unstable.skyprotocol.src} ; echo
-      echo ${toString skyprotocol.passthru.pre-pkg.gerbilInputs}
-      echo ${gerbil-poo}
+pkgs.mkShell {
+  inputsFrom = [
+    skyprotocol
+  ];
+  buildInputs = with pkgs; (
+    skyprotocol.buildInputs ++
+    lib.optional ethereum go-ethereum ++
+    [ netcat go-libp2p-daemon ] # used by integration tests
+    # TODO: Save at compile time
+    # the path to the p2pd (go-libp2p-daemon) binary.
+    # The path is useful because it is a hash -
+    # so nix knows we depend on this exact version.
+  );
+  shellHook = ''
+    echo ${gerbil-poo.src}; echo ${pkgs.gerbilPackages-unstable.gerbil-poo.src} ; echo
+    echo ${skyprotocol.src}; echo ${pkgs.gerbilPackages-unstable.skyprotocol.src} ; echo ${pkgs.gerbilPackages-unstable.skyprotocol.src} ; echo ${pkgs.gerbil-support.gerbilPackages-unstable.skyprotocol.src} ; echo
+    echo ${toString skyprotocol.passthru.pre-pkg.gerbilInputs}
+    echo ${gerbil-poo}
 
-      ${skyprotocol.postConfigure}
-      export GERBIL_LOADPATH="${pkgs.testGerbilLoadPath}"
-      PATH="${skyprotocol.out}/bin:$PATH"
-      GERBIL_APPLICATION_HOME="$PWD"
-      GERBIL_APPLICATION_SOURCE="$PWD"
-      GLOW_HOME="$PWD"
-      GLOW_SRC="$PWD"
-    '';
-  }
+    ${skyprotocol.postConfigure}
+    export GERBIL_LOADPATH="${pkgs.testGerbilLoadPath}"
+    PATH="${skyprotocol.out}/bin:$PATH"
+    GERBIL_APPLICATION_HOME="$PWD"
+    GERBIL_APPLICATION_SOURCE="$PWD"
+    GLOW_HOME="$PWD"
+    GLOW_SRC="$PWD"
+  '';
+}


### PR DESCRIPTION
Added flake, which does the same things the previous `shell.nix` and `pkgs.nix` expressions did:
1) Creates executable package `sky`
2) Adds skyprotocol as a library to gerbil

The flake also creates an overlay for future flakes that will depend on this project, exposing an executable and a gerbil library.

I have also added `.envrc` to use with direnv, for those who use it.

@fare Please test this, so that we are sure that no functionality was lost. Comment if anything is wrong and I'll fix it.

Plans for the future:
Once I familiarize myself with gerbil build system more, I plan to rewrite current `postInstall` script to make it a binary package, instead of a interpreted one(as it is right now) and expose several packages at once(interpreted, binary, library, any future package we will add here).